### PR TITLE
add flashing from Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,3 +51,5 @@ RUN cd /workdir/ncs \
 RUN echo "source /workdir/ncs/zephyr/zephyr-env.sh" >> ~/.bashrc
 RUN mkdir /workdir/.cache
 ENV XDG_CACHE_HOME=/workdir/.cache
+RUN cd /tmp && \
+    wget https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/10-7-0/nRFCommandLineTools1070Linuxamd64tar.gz && tar xvzf nRFCommandLineTools1070Linuxamd64tar.gz && dpkg -i *.deb

--- a/README.md
+++ b/README.md
@@ -48,3 +48,9 @@ You can use the pre-build image [`coderbyheart/fw-nrfconnect-nrf-docker:latest`]
     docker run --name fw-nrfconnect-nrf-docker --rm -v /tmp/fw-nrfconnect-nrf:/workdir/ncs/fw-nrfconnect-nrf coderbyheart/fw-nrfconnect-nrf-docker:latest \
       /bin/bash -c 'cd ncs/fw-nrfconnect-nrf/applications/asset_tracker; west build -p always -b nrf9160_pca20035ns'
     ls -la applications/asset_tracker/build/zephyr/merged.hex
+
+## Flashing
+
+    docker run --name fw-nrfconnect-nrf-docker --rm -v /tmp/fw-nrfconnect-nrf:/workdir/ncs/fw-nrfconnect-nrf --device=/dev/ttyACM0 \
+      coderbyheart/fw-nrfconnect-nrf-docker:latest \
+      /bin/bash -c 'cd ncs/fw-nrfconnect-nrf/applications/asset_tracker; west flash'


### PR DESCRIPTION
USB flashing can be done via Docker. No need to install SDK on your local host at all.