### PR TITLE
Minor Readme fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,12 +30,9 @@ RUN apt-get -y install ninja-build gperf git python3-setuptools && \
     # Newer PIP will not overwrite distutils, so upgrade PyYAML manually \
     python3 -m pip install --ignore-installed -U PyYAML
 ENV LC_ALL=C.UTF-8
-ENV LANG=C.UTF-8  
-# MCU boot fixes: it will fail if python-cryptography or python3-cryptography are installed 
+ENV LANG=C.UTF-8
+# MCU boot fixes: it will fail if python-cryptography or python3-cryptography are installed
 RUN apt-get -y remove python-cryptography python3-cryptography
-# Rust+Cargo
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
-ENV PATH=~/.local/bin:/usr/share/rust/.cargo/bin:$PATH
 
 # Build image, contains project-specific dependencies
 FROM base

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,52 +1,53 @@
 # Base image which contains global dependencies
-FROM ubuntu:18.04 as base
+FROM ubuntu:18.04
 WORKDIR /workdir
-RUN mkdir /workdir/ncs
-RUN mkdir /data
+
 # System dependencies
-RUN apt-get -y update && \
-    apt-get -y upgrade && \
-    apt-get -y install wget curl
-# GCC ARM Embed
-RUN mkdir /data/gcc-arm && \
-    wget -q 'https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2?revision=bc2c96c0-14b5-4bb4-9f18-bceb4050fee7?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Linux,7-2018-q2-update' \
-    -O /data/gcc-arm/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2 && \
-    tar xjf /data/gcc-arm/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2
-ENV ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
-ENV GNUARMEMB_TOOLCHAIN_PATH=/workdir/gcc-arm-none-eabi-7-2018-q2-update
-# Device Tree Compile 1.4.7
-RUN mkdir -p /data/device-tree-compiler/ && \
-    wget -q 'http://mirrors.kernel.org/ubuntu/pool/main/d/device-tree-compiler/device-tree-compiler_1.4.7-3_amd64.deb' \
-        -O /data/device-tree-compiler/device-tree-compiler_1.4.7-3_amd64.deb && \
-    dpkg -i /data/device-tree-compiler/device-tree-compiler_1.4.7-3_amd64.deb
-# Latest PIP
-RUN apt-get -y install python3-pip && \
-    python3 -m pip install -U pip
-# Zephyr dependencies
-RUN apt-get -y install ninja-build gperf git python3-setuptools && \
+RUN mkdir /workdir/ncs && \
+    apt-get -y update && apt-get -y upgrade && apt-get -y install \
+        wget \
+        python3-pip \
+        ninja-build \
+        gperf \
+        git \
+        python3-setuptools && \
+    apt-get -y remove python-cryptography python3-cryptography && \
+    apt-get -y clean && apt-get -y autoremove && \
+    mkdir tmp && cd tmp && \
+    # Device Tree Compiler 1.4.7
+    wget -q http://mirrors.kernel.org/ubuntu/pool/main/d/device-tree-compiler/device-tree-compiler_1.4.7-3_amd64.deb && \
+    # Nordic command line tools
+    wget -qO- https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/10-7-0/nRFCommandLineTools1070Linuxamd64tar.gz \
+    | tar xz && \
+    dpkg -i *.deb && \
+    cd ..; rm -rf tmp
+
+COPY . /workdir/ncs/nrf
+
+# GCC ARM Embed Toolchain
+RUN wget -qO- \
+    'https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2?revision=bc2c96c0-14b5-4bb4-9f18-bceb4050fee7?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Linux,7-2018-q2-update' \
+    | tar xj && \
+    # Latest PIP & Python dependencies
+    python3 -m pip install -U pip && \
     python3 -m pip install -U setuptools && \
     pip3 install cmake wheel && \
     pip3 install -U west && \
-    # Newer PIP will not overwrite distutils, so upgrade PyYAML manually \
-    python3 -m pip install --ignore-installed -U PyYAML
-ENV LC_ALL=C.UTF-8
-ENV LANG=C.UTF-8
-# MCU boot fixes: it will fail if python-cryptography or python3-cryptography are installed
-RUN apt-get -y remove python-cryptography python3-cryptography
-
-# Build image, contains project-specific dependencies
-FROM base
-ADD . /workdir/ncs/nrf
-# Zephyr dependencies
-RUN cd /workdir/ncs/nrf; west init -l
-RUN cd /workdir/ncs; west update
-RUN cd /workdir/ncs \
     pip3 install pc_ble_driver_py && \
+    # Newer PIP will not overwrite distutils, so upgrade PyYAML manually
+    python3 -m pip install --ignore-installed -U PyYAML && \
+    # Zephyr requirements of nrf
+    cd /workdir/ncs/nrf; west init -l && \
+    cd /workdir/ncs; west update && \
     pip3 install -r zephyr/scripts/requirements.txt && \
     pip3 install -r nrf/scripts/requirements.txt && \
-    pip3 install -r bootloader/mcuboot/scripts/requirements.txt
-RUN echo "source /workdir/ncs/zephyr/zephyr-env.sh" >> ~/.bashrc
-RUN mkdir /workdir/.cache
+    pip3 install -r bootloader/mcuboot/scripts/requirements.txt && \
+    echo "source /workdir/ncs/zephyr/zephyr-env.sh" >> ~/.bashrc && \
+    mkdir /workdir/.cache && \
+    rm -rf /workdir/ncs/nrf
+
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
 ENV XDG_CACHE_HOME=/workdir/.cache
-RUN cd /tmp && \
-    wget https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/10-7-0/nRFCommandLineTools1070Linuxamd64tar.gz && tar xvzf nRFCommandLineTools1070Linuxamd64tar.gz && dpkg -i *.deb
+ENV ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
+ENV GNUARMEMB_TOOLCHAIN_PATH=/workdir/gcc-arm-none-eabi-7-2018-q2-update

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Build the image (this is only needed once):
 
 Build the firmware for the `asset_tracker` application example:
 
-    docker run --name fw-nrfconnect-nrf-docker --rm -v ${PWD}:/workdir/ncs/fw-nrfconnect-nrf fw-nrfconnect-nrf-docker \
-      /bin/bash -c 'cd ncs/fw-nrfconnect-nrf/applications/asset_tracker; west build -p always -b nrf9160_pca20035ns'
+    docker run --rm -v ${PWD}:/workdir/ncs/nrf fw-nrfconnect-nrf-docker \
+      /bin/bash -c 'cd ncs/nrf/applications/asset_tracker; west build -p always -b nrf9160_pca20035ns'
 
 The firmware file will be in `applications/asset_tracker/build/zephyr/merged.hex`.
 
@@ -27,30 +27,49 @@ You only need to run this command to build.
 
 ## Full example
 
-    cd /tmp
     git clone https://github.com/NordicPlayground/fw-nrfconnect-nrf
     wget https://raw.githubusercontent.com/coderbyheart/fw-nrfconnect-nrf-docker/saga/Dockerfile
     cd fw-nrfconnect-nrf
     docker build --no-cache=true -t fw-nrfconnect-nrf-docker -f /tmp/Dockerfile .
-    docker run --name fw-nrfconnect-nrf-docker --rm -v /tmp/fw-nrfconnect-nrf:/workdir/ncs/fw-nrfconnect-nrf fw-nrfconnect-nrf-docker \
-      /bin/bash -c 'cd ncs/fw-nrfconnect-nrf/applications/asset_tracker; west build -p always -b nrf9160_pca20035ns'
+    docker run --rm -v ${PWD}:/workdir/ncs/nrf fw-nrfconnect-nrf-docker \
+      /bin/bash -c 'cd ncs/nrf/applications/asset_tracker; west build -p always -b nrf9160_pca20035ns'
     ls -la applications/asset_tracker/build/zephyr/merged.hex
 
-## Using prebuild image from Dockerhub
+## Using pre-built image from Dockerhub
 
 > _Note:_ This is a convenient way to quickly build your firmware but using images from untrusted third-parties poses the risk of exposing your source code.
 
-You can use the pre-build image [`coderbyheart/fw-nrfconnect-nrf-docker:latest`](https://hub.docker.com/repository/docker/coderbyheart/fw-nrfconnect-nrf-docker).
+You can use the pre-built image [`coderbyheart/fw-nrfconnect-nrf-docker:latest`](https://hub.docker.com/repository/docker/coderbyheart/fw-nrfconnect-nrf-docker).
 
-    cd /tmp
     git clone https://github.com/NordicPlayground/fw-nrfconnect-nrf
     cd fw-nrfconnect-nrf
-    docker run --name fw-nrfconnect-nrf-docker --rm -v /tmp/fw-nrfconnect-nrf:/workdir/ncs/fw-nrfconnect-nrf coderbyheart/fw-nrfconnect-nrf-docker:latest \
-      /bin/bash -c 'cd ncs/fw-nrfconnect-nrf/applications/asset_tracker; west build -p always -b nrf9160_pca20035ns'
+    docker run --rm -v ${PWD}:/workdir/ncs/nrf coderbyheart/fw-nrfconnect-nrf-docker:latest \
+      /bin/bash -c 'cd ncs/nrf/applications/asset_tracker; west build -p always -b nrf9160_pca20035ns'
     ls -la applications/asset_tracker/build/zephyr/merged.hex
 
 ## Flashing
 
-    docker run --name fw-nrfconnect-nrf-docker --rm -v /tmp/fw-nrfconnect-nrf:/workdir/ncs/fw-nrfconnect-nrf --device=/dev/ttyACM0 \
+    cd fw-nrfconnect-nrf
+    docker run --rm -v ${PWD}:/workdir/ncs/nrf --device=/dev/ttyACM0 --privileged \
       coderbyheart/fw-nrfconnect-nrf-docker:latest \
-      /bin/bash -c 'cd ncs/fw-nrfconnect-nrf/applications/asset_tracker; west flash'
+      /bin/bash -c 'cd ncs/nrf/applications/asset_tracker; west flash'
+
+## Interactive usage
+
+    cd fw-nrfconnect-nrf
+    docker run -it --name fw-nrfconnect-nrf-docker -v ${PWD}:/workdir/ncs/nrf --device=/dev/ttyACM0 --privileged \
+    coderbyheart/fw-nrfconnect-nrf-docker:latest /bin/bash
+
+Then, inside the container:
+
+    cd ncs/nrf/applications/asset_tracker
+    west build -p always -b nrf9160_pca20035ns
+    west flash
+    west build
+    ...
+
+Meanwhile, inside or outside of the container, you may modify the code and repeat the build/flash cycle.
+
+Later after closing the container you may re-open it by name to continue where you left off:
+
+    docker start -i fw-nrfconnect-nrf-docker


### PR DESCRIPTION
Hi, I have a few small improvements:

*  Rust, it is not needed
* the --privileged switch appears to be necessary for flashing
* --name is pointless while --rm is used
* ncs/nrf/ directory hierarchy is shorter and perhaps more familiar from the Nordic  docs than ncs/fw-nrfconnect-nrf
* no need to use /tmp, I think it is easier if the user can decide where to clone to
* Interactive usage example in the end

The second patch is making the image 1GB smaller by using less layers, and removing the downloaded files and the duplicate fw-nrfconnect-nrf repository. Everything still works as before.