### PR TITLE
fix: 🚚 update nrfconnect repository location

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -17,17 +17,17 @@ jobs:
       - uses: actions/checkout@master
       - name: Build image
         run: |
-          git clone https://github.com/NordicPlayground/fw-nrfconnect-nrf nrf
+          git clone https://github.com/nrfconnect/sdk-nrf nrf
           cd nrf
-          docker build -t coderbyheart/fw-nrfconnect-nrf-docker -f ../Dockerfile .
+          docker build -t coderbyheart/sdk-nrf-docker -f ../Dockerfile .
       - name: Build asset_tracker application
         run: |
           docker run --rm -v ${PWD}/nrf:/workdir/ncs/nrf \
-            coderbyheart/fw-nrfconnect-nrf-docker \
+            coderbyheart/sdk-nrf-docker \
             /bin/bash -c 'cd ncs/nrf/applications/asset_tracker; west build -p always -b nrf9160_pca20035ns'
       - name: Publish image
         run: |
           cd nrf
           docker login -u coderbyheart -p $DOCKER_PASSWORD
           docker images
-          docker push coderbyheart/fw-nrfconnect-nrf-docker
+          docker push coderbyheart/sdk-nrf-docker

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -9,11 +9,11 @@ jobs:
       - uses: actions/checkout@master
       - name: Build image
         run: |
-          git clone https://github.com/NordicPlayground/fw-nrfconnect-nrf nrf
+          git clone https://github.com/nrfconnect/sdk-nrf nrf
           cd nrf
-          docker build -t coderbyheart/fw-nrfconnect-nrf-docker -f ../Dockerfile .
+          docker build -t coderbyheart/sdk-nrf-docker -f ../Dockerfile .
       - name: Build asset_tracker application
         run: |
           docker run --rm -v ${PWD}/nrf:/workdir/ncs/nrf \
-            coderbyheart/fw-nrfconnect-nrf-docker \
+            coderbyheart/sdk-nrf-docker \
             /bin/bash -c 'cd ncs/nrf/applications/asset_tracker; west build -p always -b nrf9160_pca20035ns'

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 # Building NCS applications with Docker
 
-![Publish Docker](https://github.com/coderbyheart/fw-nrfconnect-nrf-docker/workflows/Publish%20Docker/badge.svg?branch=saga)
-(_the [Docker image](https://hub.docker.com/r/coderbyheart/fw-nrfconnect-nrf-docker) is build against [NCS](https://github.com/NordicPlayground/fw-nrfconnect-nrf) `master` every night._)
+![Publish Docker](https://github.com/coderbyheart/sdk-nrf-docker/workflows/Publish%20Docker/badge.svg?branch=saga)
+(_the [Docker image](https://hub.docker.com/r/coderbyheart/sdk-nrf-docker) is build against [NCS](https://github.com/nrfconnect/sdk-nrf) `master` every night._)
 
 ![Docker + Zephyr -> merged.hex](./diagram.png)
 
 Install `docker` on your operating system. On Windows you might want to use the [WSL subsystem](https://docs.docker.com/docker-for-windows/wsl-tech-preview/).
 
-Clone the repo: `git clone https://github.com/NordicPlayground/fw-nrfconnect-nrf`
+Clone the repo: `git clone https://github.com/nrfconnect/sdk-nrf`
 
 Copy the Dockerfile to e.g. `/tmp/Dockerfile`, you might need to adapt the installation of [the requirements](./Dockerfile#L48-L51).
 
 Build the image (this is only needed once):
 
-    cd fw-nrfconnect-nrf
-    docker build --no-cache=true -t fw-nrfconnect-nrf-docker -f /tmp/Dockerfile .
+    cd sdk-nrf
+    docker build --no-cache=true -t sdk-nrf-docker -f /tmp/Dockerfile .
 
 Build the firmware for the `asset_tracker` application example:
 
-    docker run --rm -v ${PWD}:/workdir/ncs/nrf fw-nrfconnect-nrf-docker \
+    docker run --rm -v ${PWD}:/workdir/ncs/nrf sdk-nrf-docker \
       /bin/bash -c 'cd ncs/nrf/applications/asset_tracker; west build -p always -b nrf9160_pca20035ns'
 
 The firmware file will be in `applications/asset_tracker/build/zephyr/merged.hex`.
@@ -27,11 +27,11 @@ You only need to run this command to build.
 
 ## Full example
 
-    git clone https://github.com/NordicPlayground/fw-nrfconnect-nrf
-    wget https://raw.githubusercontent.com/coderbyheart/fw-nrfconnect-nrf-docker/saga/Dockerfile
-    cd fw-nrfconnect-nrf
-    docker build --no-cache=true -t fw-nrfconnect-nrf-docker -f /tmp/Dockerfile .
-    docker run --rm -v ${PWD}:/workdir/ncs/nrf fw-nrfconnect-nrf-docker \
+    git clone https://github.com/nrfconnect/sdk-nrf
+    wget https://raw.githubusercontent.com/coderbyheart/sdk-nrf-docker/saga/Dockerfile
+    cd sdk-nrf
+    docker build --no-cache=true -t sdk-nrf-docker -f /tmp/Dockerfile .
+    docker run --rm -v ${PWD}:/workdir/ncs/nrf sdk-nrf-docker \
       /bin/bash -c 'cd ncs/nrf/applications/asset_tracker; west build -p always -b nrf9160_pca20035ns'
     ls -la applications/asset_tracker/build/zephyr/merged.hex
 
@@ -39,26 +39,26 @@ You only need to run this command to build.
 
 > _Note:_ This is a convenient way to quickly build your firmware but using images from untrusted third-parties poses the risk of exposing your source code.
 
-You can use the pre-built image [`coderbyheart/fw-nrfconnect-nrf-docker:latest`](https://hub.docker.com/r/coderbyheart/fw-nrfconnect-nrf-docker).
+You can use the pre-built image [`coderbyheart/sdk-nrf-docker:latest`](https://hub.docker.com/r/coderbyheart/sdk-nrf-docker).
 
-    git clone https://github.com/NordicPlayground/fw-nrfconnect-nrf
-    cd fw-nrfconnect-nrf
-    docker run --rm -v ${PWD}:/workdir/ncs/nrf coderbyheart/fw-nrfconnect-nrf-docker:latest \
+    git clone https://github.com/nrfconnect/sdk-nrf
+    cd sdk-nrf
+    docker run --rm -v ${PWD}:/workdir/ncs/nrf coderbyheart/sdk-nrf-docker:latest \
       /bin/bash -c 'cd ncs/nrf/applications/asset_tracker; west build -p always -b nrf9160_pca20035ns'
     ls -la applications/asset_tracker/build/zephyr/merged.hex
 
 ## Flashing
 
-    cd fw-nrfconnect-nrf
+    cd sdk-nrf
     docker run --rm -v ${PWD}:/workdir/ncs/nrf --device=/dev/ttyACM0 --privileged \
-      coderbyheart/fw-nrfconnect-nrf-docker:latest \
+      coderbyheart/sdk-nrf-docker:latest \
       /bin/bash -c 'cd ncs/nrf/applications/asset_tracker; west flash'
 
 ## Interactive usage
 
-    cd fw-nrfconnect-nrf
-    docker run -it --name fw-nrfconnect-nrf-docker -v ${PWD}:/workdir/ncs/nrf --device=/dev/ttyACM0 --privileged \
-    coderbyheart/fw-nrfconnect-nrf-docker:latest /bin/bash
+    cd sdk-nrf
+    docker run -it --name sdk-nrf-docker -v ${PWD}:/workdir/ncs/nrf --device=/dev/ttyACM0 --privileged \
+    coderbyheart/sdk-nrf-docker:latest /bin/bash
 
 Then, inside the container:
 
@@ -72,4 +72,4 @@ Meanwhile, inside or outside of the container, you may modify the code and repea
 
 Later after closing the container you may re-open it by name to continue where you left off:
 
-    docker start -i fw-nrfconnect-nrf-docker
+    docker start -i sdk-nrf-docker


### PR DESCRIPTION
The nRF Connect repositories have been moved to [a separate GitHub organization](https://github.com/nrfconnect).