### PR TITLE
fix: 🚚 update nrfconnect repository location

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@master
       - name: Build image
         run: |
-          git clone https://github.com/NordicPlayground/fw-nrfconnect-nrf nrf
+          git clone https://github.com/nrfconnect/sdk-nrf nrf
           cd nrf
           docker build -t coderbyheart/fw-nrfconnect-nrf-docker -f ../Dockerfile .
       - name: Build asset_tracker application

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@master
       - name: Build image
         run: |
-          git clone https://github.com/NordicPlayground/fw-nrfconnect-nrf nrf
+          git clone https://github.com/nrfconnect/sdk-nrf nrf
           cd nrf
           docker build -t coderbyheart/fw-nrfconnect-nrf-docker -f ../Dockerfile .
       - name: Build asset_tracker application

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # Building NCS applications with Docker
 
 ![Publish Docker](https://github.com/coderbyheart/fw-nrfconnect-nrf-docker/workflows/Publish%20Docker/badge.svg?branch=saga)
-(_the [Docker image](https://hub.docker.com/r/coderbyheart/fw-nrfconnect-nrf-docker) is build against [NCS](https://github.com/NordicPlayground/fw-nrfconnect-nrf) `master` every night._)
+(_the [Docker image](https://hub.docker.com/r/coderbyheart/fw-nrfconnect-nrf-docker) is build against [NCS](https://github.com/nrfconnect/sdk-nrf) `master` every night._)
 
 ![Docker + Zephyr -> merged.hex](./diagram.png)
 
 Install `docker` on your operating system. On Windows you might want to use the [WSL subsystem](https://docs.docker.com/docker-for-windows/wsl-tech-preview/).
 
-Clone the repo: `git clone https://github.com/NordicPlayground/fw-nrfconnect-nrf`
+Clone the repo: `git clone https://github.com/nrfconnect/sdk-nrf`
 
 Copy the Dockerfile to e.g. `/tmp/Dockerfile`, you might need to adapt the installation of [the requirements](./Dockerfile#L48-L51).
 
 Build the image (this is only needed once):
 
-    cd fw-nrfconnect-nrf
+    cd sdk-nrf
     docker build --no-cache=true -t fw-nrfconnect-nrf-docker -f /tmp/Dockerfile .
 
 Build the firmware for the `asset_tracker` application example:
@@ -27,9 +27,9 @@ You only need to run this command to build.
 
 ## Full example
 
-    git clone https://github.com/NordicPlayground/fw-nrfconnect-nrf
+    git clone https://github.com/nrfconnect/sdk-nrf
     wget https://raw.githubusercontent.com/coderbyheart/fw-nrfconnect-nrf-docker/saga/Dockerfile
-    cd fw-nrfconnect-nrf
+    cd sdk-nrf
     docker build --no-cache=true -t fw-nrfconnect-nrf-docker -f /tmp/Dockerfile .
     docker run --rm -v ${PWD}:/workdir/ncs/nrf fw-nrfconnect-nrf-docker \
       /bin/bash -c 'cd ncs/nrf/applications/asset_tracker; west build -p always -b nrf9160_pca20035ns'
@@ -41,22 +41,22 @@ You only need to run this command to build.
 
 You can use the pre-built image [`coderbyheart/fw-nrfconnect-nrf-docker:latest`](https://hub.docker.com/r/coderbyheart/fw-nrfconnect-nrf-docker).
 
-    git clone https://github.com/NordicPlayground/fw-nrfconnect-nrf
-    cd fw-nrfconnect-nrf
+    git clone https://github.com/nrfconnect/sdk-nrf
+    cd sdk-nrf
     docker run --rm -v ${PWD}:/workdir/ncs/nrf coderbyheart/fw-nrfconnect-nrf-docker:latest \
       /bin/bash -c 'cd ncs/nrf/applications/asset_tracker; west build -p always -b nrf9160_pca20035ns'
     ls -la applications/asset_tracker/build/zephyr/merged.hex
 
 ## Flashing
 
-    cd fw-nrfconnect-nrf
+    cd sdk-nrf
     docker run --rm -v ${PWD}:/workdir/ncs/nrf --device=/dev/ttyACM0 --privileged \
       coderbyheart/fw-nrfconnect-nrf-docker:latest \
       /bin/bash -c 'cd ncs/nrf/applications/asset_tracker; west flash'
 
 ## Interactive usage
 
-    cd fw-nrfconnect-nrf
+    cd sdk-nrf
     docker run -it --name fw-nrfconnect-nrf-docker -v ${PWD}:/workdir/ncs/nrf --device=/dev/ttyACM0 --privileged \
     coderbyheart/fw-nrfconnect-nrf-docker:latest /bin/bash
 


### PR DESCRIPTION
The nRF Connect repositories have been moved to [a separate GitHub organization](https://github.com/nrfconnect).