### PR TITLE
feat: update to GNU Arm Embedded Toolchain 9-2019-q4-major

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir /workdir/ncs && \
     apt-get -y clean && apt-get -y autoremove && \
     # GCC ARM Embed Toolchain
     wget -qO- \
-    'https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2018q2/gcc-arm-none-eabi-7-2018-q2-update-linux.tar.bz2?revision=bc2c96c0-14b5-4bb4-9f18-bceb4050fee7?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Linux,7-2018-q2-update' \
+    'https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2?revision=108bd959-44bd-4619-9c19-26187abf5225&la=en&hash=E788CE92E5DFD64B2A8C246BBA91A249CB8E2D2D' \
     | tar xj && \
     mkdir tmp && cd tmp && \
     # Device Tree Compiler 1.4.7
@@ -59,4 +59,4 @@ ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 ENV XDG_CACHE_HOME=/workdir/.cache
 ENV ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
-ENV GNUARMEMB_TOOLCHAIN_PATH=/workdir/gcc-arm-none-eabi-7-2018-q2-update
+ENV GNUARMEMB_TOOLCHAIN_PATH=/workdir/gcc-arm-none-eabi-9-2019-q4-major


### PR DESCRIPTION
Update to the Toolchain version required by the latest nRF Connect SDK. (assuming SDK Ver 1.4.0) 

> To be able to cross-compile your applications for Arm targets, you must install version 9-2019-q4-major of the GNU Arm Embedded Toolchain.

> Important
> Make sure to install the version that is mentioned above. Other versions might not work with this version of the nRF Connect SDK.
> 
> Note that other versions of the nRF Connect SDK might require a different toolchain version.

https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.4.0/nrf/gs_installing.html