### PR TITLE
support releases of NCS

### DIFF
--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -10,6 +10,10 @@ on:
 env:
   DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
+inputs:
+  NCS_REVISION:
+    description: 'nRF Connect SDK version'
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,12 +22,12 @@ jobs:
 
       - name: Build image
         run: |
-          docker build -t coderbyheart/fw-nrfconnect-nrf-docker .
+          docker build --build-arg NCS_REVISION=$INPUT_NCS_REVISION -t coderbyheart/fw-nrfconnect-nrf-docker:$INPUT_NCS_REVISION .
 
       - name: Build asset_tracker application
         run: |
           docker run --rm -v ${PWD}:/workdir \
-            coderbyheart/fw-nrfconnect-nrf-docker \
+            coderbyheart/fw-nrfconnect-nrf-docker:$INPUT_NCS_REVISION \
             west build -p always -b nrf9160dk_nrf9160ns --build-dir /workdir/build/ /ncs/nrf/applications/asset_tracker
 
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -18,15 +18,13 @@ jobs:
 
       - name: Build image
         run: |
-          git clone https://github.com/nrfconnect/sdk-nrf nrf
-          cd nrf
-          docker build -t coderbyheart/fw-nrfconnect-nrf-docker -f ../Dockerfile .
+          docker build -t coderbyheart/fw-nrfconnect-nrf-docker .
 
       - name: Build asset_tracker application
         run: |
-          docker run --rm -v ${PWD}/nrf:/workdir/ncs/nrf \
+          docker run --rm -v ${PWD}:/workdir \
             coderbyheart/fw-nrfconnect-nrf-docker \
-            /bin/bash -c 'cd ncs/nrf/applications/asset_tracker && west build -p always -b nrf9160dk_nrf9160ns'
+            west build -p always -b nrf9160dk_nrf9160ns --build-dir /workdir/build/ /ncs/nrf/applications/asset_tracker
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -6,13 +6,13 @@ on:
       - saga
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
+    inputs:
+      NCS_REVISION:
+        description: 'nRF Connect SDK version'
 
 env:
   DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-
-inputs:
-  NCS_REVISION:
-    description: 'nRF Connect SDK version'
 
 jobs:
   build:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -2,11 +2,6 @@ name: Verify Dockerfile
 
 on: pull_request
 
-inputs:
-  NCS_REVISION:
-    description: 'nRF Connect SDK version'
-    default: 'v1.4.2'
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,9 +9,9 @@ jobs:
       - uses: actions/checkout@master
       - name: Build image
         run: |
-          docker build --build-arg NCS_REVISION=$INPUT_NCS_REVISION -t coderbyheart/fw-nrfconnect-nrf-docker:$INPUT_NCS_REVISION .
+          docker build -t coderbyheart/fw-nrfconnect-nrf-docker .
       - name: Build asset_tracker application
         run: |
           docker run --rm \
-            coderbyheart/fw-nrfconnect-nrf-docker:$INPUT_NCS_REVISION \
+            coderbyheart/fw-nrfconnect-nrf-docker \
             west build -p always -b nrf9160dk_nrf9160ns /ncs/nrf/applications/asset_tracker

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -9,11 +9,9 @@ jobs:
       - uses: actions/checkout@master
       - name: Build image
         run: |
-          git clone https://github.com/nrfconnect/sdk-nrf nrf
-          cd nrf
-          docker build -t coderbyheart/fw-nrfconnect-nrf-docker -f ../Dockerfile .
+          docker build -t coderbyheart/fw-nrfconnect-nrf-docker .
       - name: Build asset_tracker application
         run: |
-          docker run --rm -v ${PWD}/nrf:/workdir/ncs/nrf \
+          docker run --rm \
             coderbyheart/fw-nrfconnect-nrf-docker \
-            /bin/bash -c 'cd ncs/nrf/applications/asset_tracker && west build -p always -b nrf9160dk_nrf9160ns'
+            west build -p always -b nrf9160dk_nrf9160ns /ncs/nrf/applications/asset_tracker

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -2,6 +2,11 @@ name: Verify Dockerfile
 
 on: pull_request
 
+inputs:
+  NCS_REVISION:
+    description: 'nRF Connect SDK version'
+    default: 'v1.4.2'
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -9,9 +14,9 @@ jobs:
       - uses: actions/checkout@master
       - name: Build image
         run: |
-          docker build -t coderbyheart/fw-nrfconnect-nrf-docker .
+          docker build --build-arg NCS_REVISION=$INPUT_NCS_REVISION -t coderbyheart/fw-nrfconnect-nrf-docker:$INPUT_NCS_REVISION .
       - name: Build asset_tracker application
         run: |
           docker run --rm \
-            coderbyheart/fw-nrfconnect-nrf-docker \
+            coderbyheart/fw-nrfconnect-nrf-docker:$INPUT_NCS_REVISION \
             west build -p always -b nrf9160dk_nrf9160ns /ncs/nrf/applications/asset_tracker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,65 +1,55 @@
+# Source: https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/gs_installing.html
+
 # Base image which contains global dependencies
-FROM ubuntu:20.04 as base
-WORKDIR /workdir
+FROM ubuntu:20.10 as base
+WORKDIR /ncs
+
+ARG NCS_REVISION=master
+ENV NCS_REVISION=${NCS_REVISION}
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 # System dependencies
-RUN mkdir /workdir/ncs && \
-    apt-get -y update && \
+RUN apt-get -y update && \
     apt-get -y upgrade && \
-    apt-get -y install \
-        wget \
-        python3-pip \
-        ninja-build \
-        gperf \
-        git \
-        python3-setuptools \
-        libncurses5 libncurses5-dev \
-        libyaml-dev libfdt1 && \
-    apt-get -y remove python-cryptography python3-cryptography && \
-    apt-get -y clean && apt-get -y autoremove && \
+    apt install -y --no-install-recommends \
+        git cmake ninja-build gperf \
+        ccache dfu-util device-tree-compiler wget \
+        python3-dev python3-pip python3-setuptools python3-tk python3-wheel xz-utils file \
+        make gcc gcc-multilib g++-multilib libsdl2-dev \
+        # process .tar.bz2
+        bzip2  \
+        # nRF-command-line-tools dependency
+        libncurses5 && \
+    rm -rf /var/lib/apt/lists/* && \
     # GCC ARM Embed Toolchain
     wget -qO- \
     'https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2?revision=108bd959-44bd-4619-9c19-26187abf5225&la=en&hash=E788CE92E5DFD64B2A8C246BBA91A249CB8E2D2D' \
     | tar xj && \
     mkdir tmp && cd tmp && \
-    # Device Tree Compiler 1.5.1 (for Ubuntu 20.04)
-    # Releases: https://git.kernel.org/pub/scm/utils/dtc/dtc.git
-    wget -q http://archive.ubuntu.com/ubuntu/pool/main/d/device-tree-compiler/device-tree-compiler_1.5.1-1_amd64.deb && \
     # Nordic command line tools
-    # Releases: https://www.nordicsemi.com/Software-and-tools/Development-Tools/nRF-Command-Line-Tools/Download
     wget -qO- https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/10-12-1/nRFCommandLineTools10121Linuxamd64.tar.gz \
     | tar xz && \
     dpkg -i *.deb && \
-    cd .. && rm -rf tmp && \
-    # Latest PIP & Python dependencies
-    python3 -m pip install -U pip && \
-    python3 -m pip install -U setuptools && \
-    python3 -m pip install cmake wheel && \
-    python3 -m pip install -U west==0.9.0 && \
-    python3 -m pip install pc_ble_driver_py && \
-    # Newer PIP will not overwrite distutils, so upgrade PyYAML manually
-    python3 -m pip install --ignore-installed -U PyYAML && \
-    # ClangFormat
-    python3 -m pip install -U six && \
-    apt-get -y install clang-format-9 && \
-    ln -s /usr/bin/clang-format-9 /usr/bin/clang-format && \
-    wget -qO- https://raw.githubusercontent.com/nrfconnect/sdk-nrf/master/.clang-format > /workdir/.clang-format
+    cd .. && rm -rf tmp
 
 # Build image, contains project-specific dependencies
 FROM base
-COPY . /workdir/ncs/nrf
-RUN \
+COPY entrypoint.sh .
+RUN chmod +x ./entrypoint.sh && \
     # Zephyr requirements of nrf
-    cd /workdir/ncs/nrf && west init -l && \
-    cd /workdir/ncs && west update && \
-    python3 -m pip install -r zephyr/scripts/requirements.txt && \
-    python3 -m pip install -r nrf/scripts/requirements.txt && \
-    python3 -m pip install -r bootloader/mcuboot/scripts/requirements.txt && \
-    echo "source /workdir/ncs/zephyr/zephyr-env.sh" >> ~/.bashrc && \
-    mkdir /workdir/.cache
+    pip3 install -U west && \
+    west init -m https://github.com/nrfconnect/sdk-nrf --mr ${NCS_REVISION} && \
+    west update && \
+    west zephyr-export && \
+    pip3 install -r zephyr/scripts/requirements.txt && \
+    pip3 install -r nrf/scripts/requirements.txt && \
+    pip3 install -r bootloader/mcuboot/scripts/requirements.txt && \
+    pip3 cache purge && rm -rf /root/.cache
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
-ENV XDG_CACHE_HOME=/workdir/.cache
 ENV ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
-ENV GNUARMEMB_TOOLCHAIN_PATH=/workdir/gcc-arm-none-eabi-9-2019-q4-major
+ENV GNUARMEMB_TOOLCHAIN_PATH=/ncs/gcc-arm-none-eabi-9-2019-q4-major
+
+ENTRYPOINT ["/ncs/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,12 @@ RUN apt-get -y update && \
     | tar xj && \
     mkdir tmp && cd tmp && \
     # Nordic command line tools
+    # Releases: https://www.nordicsemi.com/Software-and-tools/Development-Tools/nRF-Command-Line-Tools/Download
     wget -qO- https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/10-12-1/nRFCommandLineTools10121Linuxamd64.tar.gz \
     | tar xz && \
     dpkg -i *.deb && \
-    cd .. && rm -rf tmp
+    cd .. && rm -rf tmp && \
+    pip3 install -U pip
 
 # Build image, contains project-specific dependencies
 FROM base

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,9 @@ RUN apt-get -y update && \
     mkdir tmp && cd tmp && \
     # Nordic command line tools
     # Releases: https://www.nordicsemi.com/Software-and-tools/Development-Tools/nRF-Command-Line-Tools/Download
-    wget -q https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/10-13-0/nRF-Command-Line-Tools_10_13_0_Linux64.zip && \
-    unzip nRF-Command-Line-Tools_10_13_0_Linux64.zip && \
-    tar xvzf nRF-Command-Line-Tools_10_13_0_Linux64/nRF-Command-Line-Tools_10_13_0_Linux-amd64.tar.gz && \
-    dpkg -i *.deb && \
+    wget -q https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/10-14-0/nRF-Command-Line-Tools_10_14_0_Linux64.zip && \
+    unzip nRF-Command-Line-Tools_10_14_0_Linux64.zip && \
+    dpkg --install nRF-Command-Line-Tools_10_14_0_Linux64/*.deb && \
     cd .. && rm -rf tmp && \
     pip3 install -U pip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ RUN apt-get -y update && \
         ccache dfu-util device-tree-compiler wget \
         python3-dev python3-pip python3-setuptools python3-tk python3-wheel xz-utils file \
         make gcc gcc-multilib g++-multilib libsdl2-dev \
-        # process .tar.bz2
-        bzip2  \
+        # process .zip & .tar.bz2
+        unzip bzip2 \
         # nRF-command-line-tools dependency
         libncurses5 && \
     rm -rf /var/lib/apt/lists/* && \

--- a/README.md
+++ b/README.md
@@ -7,37 +7,18 @@
 
 Install `docker` on your operating system. On Windows you might want to use the [WSL subsystem](https://docs.docker.com/docker-for-windows/wsl-tech-preview/).
 
-Clone the repo:
-
-    git clone https://github.com/nrfconnect/sdk-nrf
-
-Copy the Dockerfile to e.g. `/tmp/Dockerfile`, you might need to adapt the installation of [the requirements](./Dockerfile#L48-L51).
-
-    wget https://raw.githubusercontent.com/coderbyheart/fw-nrfconnect-nrf-docker/saga/Dockerfile -O /tmp/Dockerfile
-
 Build the image (this is only needed once):
 
-    cd sdk-nrf
-    docker build --no-cache=true -t fw-nrfconnect-nrf-docker -f /tmp/Dockerfile .
+    docker build --no-cache=true -t fw-nrfconnect-nrf-docker .
 
 Build the firmware for the `asset_tracker` application example:
 
-    docker run --rm -v ${PWD}:/workdir/ncs/nrf fw-nrfconnect-nrf-docker \
-      /bin/bash -c 'cd ncs/nrf/applications/asset_tracker && west build -p always -b nrf9160dk_nrf9160ns'
+    docker run --rm -v ${PWD}:/workdir fw-nrfconnect-nrf-docker \
+      west build -p always -b nrf9160dk_nrf9160ns --build-dir /workdir/build/ /ncs/nrf/applications/asset_tracker
 
-The firmware file will be in `applications/asset_tracker/build/zephyr/merged.hex`.
+The firmware file will be in `./build/zephyr/merged.hex`.
 
 You only need to run this command to build.
-
-## Full example
-
-    git clone https://github.com/nrfconnect/sdk-nrf
-    wget https://raw.githubusercontent.com/coderbyheart/fw-nrfconnect-nrf-docker/saga/Dockerfile -O /tmp/Dockerfile
-    cd sdk-nrf
-    docker build --no-cache=true -t fw-nrfconnect-nrf-docker -f /tmp/Dockerfile .
-    docker run --rm -v ${PWD}:/workdir/ncs/nrf fw-nrfconnect-nrf-docker \
-      /bin/bash -c 'cd ncs/nrf/applications/asset_tracker && west build -p always -b nrf9160dk_nrf9160ns'
-    ls -la applications/asset_tracker/build/zephyr/merged.hex
 
 ## Using pre-built image from Dockerhub
 
@@ -45,26 +26,23 @@ You only need to run this command to build.
 
 You can use the pre-built image [`coderbyheart/fw-nrfconnect-nrf-docker:latest`](https://hub.docker.com/r/coderbyheart/fw-nrfconnect-nrf-docker).
 
-    git clone https://github.com/nrfconnect/sdk-nrf
-    cd sdk-nrf
-    docker run --rm -v ${PWD}:/workdir/ncs/nrf coderbyheart/fw-nrfconnect-nrf-docker:latest \
-      /bin/bash -c 'cd ncs/nrf/applications/asset_tracker && west build -p always -b nrf9160dk_nrf9160ns'
-    ls -la applications/asset_tracker/build/zephyr/merged.hex
+    docker run --rm -v ${PWD}:/workdir coderbyheart/fw-nrfconnect-nrf-docker:latest \
+      west build -p always -b nrf9160dk_nrf9160ns --build-dir /workdir/build/ /ncs/nrf/applications/asset_tracker
+    ls -la ./build/zephyr/merged.hex
 
 ### Build a Zephyr sample
 
 This builds the `hci_uart` sample and stores the `hci_uart.hex` file in the current directory:
 
-    docker run --rm -v ${PWD}:/workdir/ncs/nrf coderbyheart/fw-nrfconnect-nrf-docker:latest \
-        /bin/bash -c 'cd ncs/zephyr && west build samples/bluetooth/hci_uart -p always -b nrf9160dk_nrf52840 && \
-        ls -la build/zephyr && cp build/zephyr/zephyr.hex /workdir/ncs/nrf/hci_uart.hex'
+    docker run --rm -v ${PWD}:/workdir coderbyheart/fw-nrfconnect-nrf-docker:latest \
+        west build /ncs/zephyr/samples/bluetooth/hci_uart -p always -b nrf9160dk_nrf52840 --build-dir /workdir/build/
+    ls -la build/zephyr && cp build/zephyr/zephyr.hex hci_uart.hex
 
 ## Flashing
 
-    cd sdk-nrf
-    docker run --rm -v ${PWD}:/workdir/ncs/nrf --device=/dev/ttyACM0 --privileged \
+    docker run --rm --device=/dev/ttyACM0 --privileged \
       coderbyheart/fw-nrfconnect-nrf-docker:latest \
-      /bin/bash -c 'cd ncs/nrf/applications/asset_tracker && west flash'
+      cd ncs/nrf/applications/asset_tracker && west flash
 
 ## ClangFormat
 
@@ -85,13 +63,12 @@ to format your sources.
 
 ## Interactive usage
 
-    cd sdk-nrf
-    docker run -it --name fw-nrfconnect-nrf-docker -v ${PWD}:/workdir/ncs/nrf --device=/dev/ttyACM0 --privileged \
+    docker run -it --name fw-nrfconnect-nrf-docker --device=/dev/ttyACM0 --privileged \
     coderbyheart/fw-nrfconnect-nrf-docker:latest /bin/bash
 
 Then, inside the container:
 
-    cd ncs/nrf/applications/asset_tracker
+    cd /ncs/nrf/applications/asset_tracker
     west build -p always -b nrf9160_pca20035ns
     west flash
     west build

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Read in the file of environment settings
+. /ncs/zephyr/zephyr-env.sh
+# Then run the CMD
+exec "$@"


### PR DESCRIPTION
TBD: update readme

Released versions can be build using

`docker build --build-arg NCS_REVISION=${NCS_REVISION} -t fw-nrfconnect-nrf-docker:${NCS_REVISION} .`

Tested with v1.4.x. The latest v1.5.0 failed due to https://github.com/nrfconnect/sdk-nrf/pull/4053

Usage: 
```
docker run --rm -v ${PWD}:/workspace fw-nrfconnect-nrf-docker:${NCS_REVISION} \
  west build -p always -b nrf9160dk_nrf9160ns --build-dir /workspace/build/ -- -DCONFIG_SB_SIGNING_KEY_FILE=\"vendor.pem\" /workspace

```

