### PR TITLE
feat: add linux/arm64 architecture for Apple M1 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:20.04 as base
 WORKDIR /workdir
 
 # System dependencies
+ARG arch=amd64
 RUN mkdir /workdir/ncs && \
     apt-get -y update && \
     apt-get -y upgrade && \
@@ -16,23 +17,39 @@ RUN mkdir /workdir/ncs && \
         python3-setuptools \
         libncurses5 libncurses5-dev \
         libyaml-dev libfdt1 \
-        libusb-1.0-0-dev udev && \
+        libusb-1.0-0-dev udev \
+        device-tree-compiler=1.5.1-1 \
+        ruby && \
     apt-get -y clean && apt-get -y autoremove && \
     # GCC ARM Embed Toolchain
-    wget -qO- \
-    'https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2?revision=108bd959-44bd-4619-9c19-26187abf5225&la=en&hash=E788CE92E5DFD64B2A8C246BBA91A249CB8E2D2D' \
-    | tar xj && \
-    mkdir tmp && cd tmp && \
-    # Device Tree Compiler 1.5.1 (for Ubuntu 20.04)
-    # Releases: https://git.kernel.org/pub/scm/utils/dtc/dtc.git
-    wget -q http://archive.ubuntu.com/ubuntu/pool/main/d/device-tree-compiler/device-tree-compiler_1.5.1-1_amd64.deb && \
+    echo "Target architecture: $arch" && \
+    case $arch in \
+        "amd64") \
+            NCLT_URL="https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/10-15-0/nrf-command-line-tools-10.15.0_amd.zip" \
+            ARM_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2?revision=108bd959-44bd-4619-9c19-26187abf5225&la=en&hash=E788CE92E5DFD64B2A8C246BBA91A249CB8E2D2D" \
+            ;; \
+        "arm64") \
+            NCLT_URL="" \
+            ARM_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-aarch64-linux.tar.bz2?revision=4583ce78-e7e7-459a-ad9f-bff8e94839f1&hash=CF9005177C5564B8A88F71AF541808EB" \
+            ;; \
+        *) \
+            echo "Unsupported TARGETARCH: \"$TARGETARCH\"" >&2 && \
+            exit 1 ;; \
+    esac && \
+    wget -qO - "${ARM_URL}" | tar xj && \
     # Nordic command line tools
     # Releases: https://www.nordicsemi.com/Software-and-tools/Development-Tools/nRF-Command-Line-Tools/Download
-    wget -q https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/10-15-0/nrf-command-line-tools-10.15.0_amd.zip && \
-    unzip nrf-command-line-tools-10.15.0_amd.zip && \
-    tar xzf nrf-command-line-tools-10.15.0_Linux-amd64.tar.gz && \
-    dpkg -i *.deb && \
-    cd .. && rm -rf tmp && \
+    # Doesn´t exist for arm64, but not necessary for building
+    if [ ! -z "$NCLT_URL" ]; then \
+        mkdir tmp && cd tmp && \
+        wget -q "${NCLT_URL}" && \
+        unzip nrf-command-line-tools-*.zip && \
+        tar xzf nrf-command-line-tools-*.tar.gz && \
+        dpkg -i *.deb && \
+        cd .. && rm -rf tmp ; \
+    else \
+        echo "Skipping nRF Command Line Tools (not available for $arch)" ; \
+    fi && \
     # Latest PIP & Python dependencies
     python3 -m pip install -U pip && \
     python3 -m pip install -U setuptools && \

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Build the image (this is only needed once):
     cd sdk-nrf
     docker build --no-cache=true -t fw-nrfconnect-nrf-docker -f /tmp/Dockerfile .
 
+> _Note:_ To build for a Mac with the M1 architecture, you need to specify the `arm64` architecutre when building: `--build-arg arch=arm64`.
+
 Build the firmware for the `asset_tracker` application example:
 
     docker run --rm -v ${PWD}:/workdir/ncs/nrf fw-nrfconnect-nrf-docker \
@@ -46,6 +48,8 @@ You only need to run this command to build.
 ## Using pre-built image from Dockerhub
 
 > _Note:_ This is a convenient way to quickly build your firmware but using images from untrusted third-parties poses the risk of exposing your source code.
+
+> _Note 2:_ The prebuilt images are not available for `arm64` architecture (Apple M1), since GitHub Actions don't have hosted runners with Apple M1 yet.
 
 You can use the pre-built image [`coderbyheart/fw-nrfconnect-nrf-docker:main`](https://hub.docker.com/r/coderbyheart/fw-nrfconnect-nrf-docker).
 


### PR DESCRIPTION
Docker needs to run on the host computers architecture. On new Mac computers with the Apple M1 CPU, this is arm64. So the binary dependencies needs to match the architecture.

- _device-tree-compiler_ Couldn't find a binary for arm64, but it's available with apt.
- _gcc-arm-none-eabi_ Updated logic to download binary matching the architecture.
- _nRF Command Line Tools_ Ignoring for `arm64` since it's not available, and USB is not available for macOS inside Docker anyways.

I also added ruby to the apt-get install because it's required to run at least some of our unit tests.